### PR TITLE
Save entity in two queries

### DIFF
--- a/bitcoingraph/entities.py
+++ b/bitcoingraph/entities.py
@@ -273,28 +273,6 @@ class EntityGrouping:
             self.entity_idx_counter += 1
             self.counter_entities += 1
 
-    # def empty_old(self, distance: int):
-    #     to_delete = set([])
-    #     to_return = {}
-    #     for entity_idx, last_updated_value in self.last_updated.items():
-    #         if self.entity_idx_counter - last_updated_value > distance:
-    #
-    #             address_set = self.entity_idx_to_addresses[entity_idx]
-    #             self.entity_idx_to_addresses[entity_idx] = None
-    #             for addr in address_set:
-    #                 self.address_to_entity_idx.pop(addr)
-    #
-    #             to_delete.add(entity_idx)
-    #             to_return[entity_idx] = address_set
-    #
-    #     for k in to_delete:
-    #         self.last_updated.pop(k)
-    #
-    #     self.last_empty = self.entity_idx_counter
-    #     return to_return
-
-
-
     def save_entities(self, session: 'neo4j.Session', display_progress=False):
         if display_progress:
             raise DeprecationWarning("Not maintained")
@@ -345,46 +323,6 @@ class EntityGrouping:
                 MATCH (a:Address {address: address})
                 MERGE (a)<-[:OWNER_OF]-(e)
                 """, entity_id=addresses[0], addresses=addresses)
-            #
-            # result = session.run("""
-            # UNWIND $addresses as address
-            # MATCH (a:Address {address: address})
-            # WITH a
-            # OPTIONAL MATCH (a)<-[:OWNER_OF]-(e:Entity)
-            # WITH a, e
-            # WITH collect(distinct a) as addrs, collect(distinct e) as entities
-            # WITH addrs, addrs[0].address as minA, entities[0] as minEntity, tail(entities) as entities
-            #
-            # // Keeping entity name or creating new one
-            # WITH *, coalesce(reduce(s = coalesce(minEntity.name, ""), node IN entities | s+"+"+node.name), minEntity.name) AS entityName
-            # WITH *, CASE
-            #     WHEN entityName STARTS WITH "+" THEN substring(entityName, 1)
-            #     ELSE entityName
-            # END AS entityName
-            #
-            # CALL {
-            #     WITH minEntity, addrs, minA
-            #     WITH minEntity, addrs, minA WHERE minEntity IS NULL
-            #     CREATE (e:Entity {entity_id: minA})
-            #     WITH *
-            #     UNWIND addrs as a
-            #     MERGE (e)-[:OWNER_OF]->(a)
-            #
-            #     UNION
-            #
-            #     WITH minEntity, addrs, entities, entityName
-            #     WITH minEntity, addrs, entities, entityName
-            #         WHERE minEntity IS NOT NULL
-            #     SET minEntity.name = entityName
-            #     WITH *
-            #     MATCH (a:Address) WHERE a in addrs
-            #     MERGE (minEntity)-[:OWNER_OF]->(a)
-            #     WITH entities
-            #     UNWIND entities as e
-            #     MATCH (e)
-            #     DETACH DELETE (e)
-            # }
-            # """, addresses=list(addresses))
 
 
 def add_entities(batch_size: int, resume: str, driver: 'neo4j.Driver'):

--- a/bitcoingraph/entities.py
+++ b/bitcoingraph/entities.py
@@ -305,6 +305,7 @@ class EntityGrouping:
         for entity_idx, addresses in tqdm.tqdm(iterator, desc="Adding entities"):
             if len(addresses) <= 1:
                 continue
+            addresses = list(addresses)
 
             result = session.run("""
             UNWIND $addresses as address

--- a/bitcoingraph/logger.py
+++ b/bitcoingraph/logger.py
@@ -16,7 +16,7 @@ def get_logger(name):
 
     logger = root_logger.getChild(name)
 
-    formatter = logging.Formatter('[%(levelname)s] - [%(name)s] - %(message)s')
+    formatter = logging.Formatter('[%(levelname)s]-[%(name)s]-[%(asctime)s]-%(message)s')
     stream_handler = logging.StreamHandler()
     stream_handler.setFormatter(formatter)
     logger.addHandler(stream_handler)


### PR DESCRIPTION
Instead of doing one large query which neo4j seems to have troubles with, we separate into two queries interlaced with some python: 
1. get the addresses and current entities
2. process in python (entity name, entity id)
3. create/merge the entities, and connect the address